### PR TITLE
[CHORE] remove debug print on init

### DIFF
--- a/src/httpmorph/__init__.py
+++ b/src/httpmorph/__init__.py
@@ -6,8 +6,6 @@ High-performance HTTP/HTTPS client with dynamic browser fingerprinting.
 Built from scratch in C with BoringSSL. No fallback implementations.
 """
 
-import sys
-
 # Read version from package metadata (single source of truth: pyproject.toml)
 try:
     from importlib.metadata import version as _get_version
@@ -63,8 +61,6 @@ if not HAS_C_EXTENSION:
         "Please ensure the package was built correctly with: "
         "python setup.py build_ext --inplace"
     )
-
-print("[httpmorph] Using C extension with BoringSSL", file=sys.stderr)
 
 # Import async client (C-level async I/O with kqueue/epoll)
 try:

--- a/src/httpmorph/_client_c.py
+++ b/src/httpmorph/_client_c.py
@@ -68,8 +68,7 @@ try:
     else:
         raise ImportError("Could not create module spec")
 
-except (ImportError, Exception) as e:
-    print(f"WARNING: Failed to import _httpmorph: {e}", file=sys.stderr)
+except (ImportError, Exception):
     HAS_C_EXTENSION = False
     _httpmorph = None
 


### PR DESCRIPTION
Removed automatic debug output that was printed every time httpmorph was imported, making the library silent unless errors occur. This improves user experience by eliminating unnecessary stderr output.